### PR TITLE
FIX - undefined account Id on close of widget

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,37 +1,41 @@
 'use strict';
 
 // Update the following variables with your own values
-const apiKey = '';
-const userId = '';
-const vendorId = '';
+const apiKey = ''; //Add Api Key here
+const userId = ''; // Add your user ID here
+const vendorId = ''; // Add your vendor ID here
 
-document.addEventListener("DOMContentLoaded", function () {
-    window.grailpay.init({
-        containerId: "widget-container",
-        vendorId: vendorId,
-        userId: userId,
-        token: apiKey,
-        onError: (error) => {
-            console.log( "GrailPay.onError", error)
-        },
-        onClose: (data) => {
-            console.log( "GrailPay.onClose", data)
+document.addEventListener('DOMContentLoaded', function () {
+    const payButton = document.getElementById('pay-button');
 
-            let responseContainer = document.getElementById('response-container');
-            if( responseContainer ){
-                responseContainer.innerHTML = `AccountId: ${data.accountId}`
+    if (payButton) {
+        payButton.disabled = true;
+
+        window.grailpay.init({
+            containerId: 'widget-container',
+            vendorId: vendorId,
+            userId: userId,
+            token: apiKey,
+            onError: function (error) {
+                console.log('GrailPay.onError', error);
+            },
+            onClose: function (data) {
+                console.log('GrailPay.onClose', data);
+                let responseContainer = document.getElementById('response-container');
+
+                if (responseContainer) {
+                    responseContainer.innerHTML = data?.accountId ? `AccountId: ${data.accountId}` : '';
+                }
             }
-        },
-    }).then((res) => {
-        if( res.status === 200 ){
-            console.log( "GrailPay Banklink Widget initialized successfully")
-        }
-    }).catch(err => console.log(err, 'err'))
-        .finally(() => {
+        }).then(function (res) {
+            if (res.status === 200) {
+                payButton.disabled = false;
+                console.log('GrailPay Banklink Widget initialized successfully');
+            }
+        }).catch(function (err) {
+            console.log(err, 'Error initializing GrailPay Banklink Widget');
         });
 
-    const payButton = document.getElementById('pay-button');
-    if( payButton ){
         payButton.addEventListener('click', function () {
             window.grailpay.open();
         });


### PR DESCRIPTION
Fixed below issues.

1) Fixed showing undefined Account Id on close.
2) Disabled the 'Link Bank Account' button until the widget is initialized